### PR TITLE
Add dist-newstyle to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.png
+dist-newstyle/


### PR DESCRIPTION
I assume that you have `dist-newstyle` in your global `gitignore`, but this might be helpful if anyone else decides to contribute.