### PR TITLE
Dimensionless quantities

### DIFF
--- a/src/Data/Functor/I.hs
+++ b/src/Data/Functor/I.hs
@@ -1,0 +1,2 @@
+module Data.Functor.I
+() where

--- a/src/Data/Functor/I.hs
+++ b/src/Data/Functor/I.hs
@@ -1,5 +1,16 @@
+{-# LANGUAGE DeriveTraversable #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Data.Functor.I
 ( I(..)
 ) where
 
+import Data.Functor.Identity
+import Linear
+import Foreign.Storable
+import GL.Type as GL
+import GL.Uniform
+
 newtype I a = I { getI :: a }
+ deriving (Conjugate, Epsilon, Enum, Eq, Foldable, Floating, Fractional, Functor, Integral, Num, Ord, Real, RealFloat, RealFrac, Scalar, Show, Storable, Traversable, GL.Type, Uniform)
+  deriving (Additive, Applicative, Metric, Monad) via Identity

--- a/src/Data/Functor/I.hs
+++ b/src/Data/Functor/I.hs
@@ -1,2 +1,5 @@
 module Data.Functor.I
-() where
+( I(..)
+) where
+
+newtype I a = I { getI :: a }

--- a/src/Data/Functor/I.hs
+++ b/src/Data/Functor/I.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DeriveTraversable #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+-- | I got sick of writing 'Identity' out in full.
 module Data.Functor.I
 ( I(..)
 ) where

--- a/src/GL/Type.hs
+++ b/src/GL/Type.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE StandaloneDeriving #-}
 module GL.Type
 ( Type(..)
 ) where
@@ -60,12 +62,5 @@ instance Type (f a) => Type (Point f a) where
 
   glDims = P <$> glDims
 
-instance Type a => Type (Const a b) where
-  glType = Const <$> glType
-
-  glDims = Const <$> glDims
-
-instance Type a => Type (Identity a) where
-  glType = Identity <$> glType
-
-  glDims = Identity <$> glDims
+deriving instance Type a => Type (Const a b)
+deriving instance Type a => Type (Identity a)

--- a/src/GL/Uniform.hs
+++ b/src/GL/Uniform.hs
@@ -13,6 +13,7 @@ module GL.Uniform
 
 import           Control.Monad.IO.Class.Lift
 import           Data.Coerce
+import           Data.Functor.Const
 import           Data.Functor.Identity
 import           Data.Int
 import qualified Foreign.Marshal.Utils.Lift as A
@@ -64,6 +65,7 @@ instance {-# OVERLAPPABLE #-} Scalar t => Uniform (V4 t) where
 
 deriving instance Uniform (f a) => Uniform (Point f a)
 
+deriving instance Uniform a => Uniform (Const a b)
 deriving instance Uniform a => Uniform (Identity a)
 
 

--- a/src/GL/Uniform.hs
+++ b/src/GL/Uniform.hs
@@ -13,6 +13,7 @@ module GL.Uniform
 
 import           Control.Monad.IO.Class.Lift
 import           Data.Coerce
+import           Data.Functor.Identity
 import           Data.Int
 import qualified Foreign.Marshal.Utils.Lift as A
 import           Foreign.Ptr
@@ -62,6 +63,8 @@ instance {-# OVERLAPPABLE #-} Scalar t => Uniform (V4 t) where
   uniform prog loc vec = A.with vec (sendM . uniformFor @t C4x1 prog loc 1 . castPtr)
 
 deriving instance Uniform (f a) => Uniform (Point f a)
+
+deriving instance Uniform a => Uniform (Identity a)
 
 
 -- | Types which can appear in vectors.

--- a/src/Starlight/Physics.hs
+++ b/src/Starlight/Physics.hs
@@ -58,7 +58,7 @@ gravity a = do
     force = (a^.mass_ .*. b^.mass_ ./. r) .*. gravC
     -- FIXME: gravity seems extremely weak
     r :: (Metres :*: Metres) Double
-    r = pure $ fmap (getMetres . convert) (b^.position_) `qd` fmap (getMetres . convert) (a^.position_) -- “quadrance” (square of distance between actor & body)
+    r = (b^.position_.to (fmap convert)) `qdU` (a^.position_.to (fmap convert)) -- “quadrance” (square of distance between actor & body)
   gravC :: (Metres :*: Metres :*: Metres :/: Kilo Grams :/: Seconds :/: Seconds) Double
   gravC = 6.67430e-11
 

--- a/src/Starlight/System.hs
+++ b/src/Starlight/System.hs
@@ -88,7 +88,7 @@ neighbourhoodOf c sys@System{ bodies, characters } = sys
     received :: Mega Watts Double
     received = (c^.ship_.radar_.power_ .*. gain .*. aperture .*. crossSection .*. patternPropagationFactor ** 4) ./. (I ((4 * pi) ** 2) .*. r .*. r)
     crossSection :: (Metres :*: Metres) Double
-    crossSection = convert @_ @Metres (a^.actor_.magnitude_) .*. convert @_ @Metres (a^.actor_.magnitude_)
+    crossSection = a^.actor_.magnitude_.converting @_ @Metres .*. a^.actor_.magnitude_.converting @_ @Metres
     r :: (Metres :*: Metres) Double
     r = pure $ fmap (getMetres . convert) (a^.actor_.position_) `qd` fmap (getMetres . convert) (c^.actor_.position_)
   aperture :: (Metres :*: Metres) Double

--- a/src/Starlight/System.hs
+++ b/src/Starlight/System.hs
@@ -19,6 +19,7 @@ module Starlight.System
 
 import           Control.Effect.Lens.Exts (asserting)
 import           Control.Lens (Lens, Lens', at, iso, ix, lens, (^.), (^?))
+import           Data.Coerce
 import           Data.Generics.Product.Fields
 import qualified Data.Map.Strict as Map
 import           Data.Maybe (fromMaybe)
@@ -87,12 +88,12 @@ neighbourhoodOf c sys@System{ bodies, characters } = sys
     where
     received :: Pico Watts Double
     received = (c^.ship_.radar_.power_.convertingTo (Pico . Watts) .*. gain .*. aperture .*. crossSection .*. patternPropagationFactor ** 4) ./. (I ((4 * pi) ** 2) .*. r .*. r)
-    crossSection :: (Metres :*: Metres) Double
-    crossSection = a^.actor_.magnitude_.convertingTo Metres .*. a^.actor_.magnitude_.convertingTo Metres
-    r :: (Metres :*: Metres) Double
-    r = pure $ fmap (getMetres . convert) (a^.actor_.position_) `qd` fmap (getMetres . convert) (c^.actor_.position_)
-  aperture :: (Metres :*: Metres) Double
-  aperture = 1000
+    crossSection :: (Mega Metres :*: Mega Metres) Double
+    crossSection = a^.actor_.magnitude_ .*. a^.actor_.magnitude_
+    r :: (Mega Metres :*: Mega Metres) Double
+    r = coerce $ (a^.actor_.position_) `qd` (c^.actor_.position_)
+  aperture :: (Mega Metres :*: Mega Metres) Double
+  aperture = 10
   gain :: I Double
   gain = 1
   patternPropagationFactor :: I Double

--- a/src/Starlight/System.hs
+++ b/src/Starlight/System.hs
@@ -19,13 +19,11 @@ module Starlight.System
 
 import           Control.Effect.Lens.Exts (asserting)
 import           Control.Lens (Lens, Lens', at, iso, ix, lens, (^.), (^?))
-import           Data.Coerce
 import           Data.Generics.Product.Fields
 import qualified Data.Map.Strict as Map
 import           Data.Maybe (fromMaybe)
 import           GHC.Generics (Generic)
 import           GHC.Stack (HasCallStack)
-import           Linear.Exts
 import           Starlight.Actor
 import           Starlight.Character
 import           Starlight.Identifier
@@ -91,7 +89,7 @@ neighbourhoodOf c sys@System{ bodies, characters } = sys
     crossSection :: (Mega Metres :*: Mega Metres) Double
     crossSection = a^.actor_.magnitude_ .*. a^.actor_.magnitude_
     r :: (Mega Metres :*: Mega Metres) Double
-    r = coerce $ (a^.actor_.position_) `qd` (c^.actor_.position_)
+    r = (a^.actor_.position_) `qdU` (c^.actor_.position_)
   aperture :: (Mega Metres :*: Mega Metres) Double
   aperture = 10
   gain :: I Double

--- a/src/Starlight/System.hs
+++ b/src/Starlight/System.hs
@@ -83,10 +83,10 @@ neighbourhoodOf c sys@System{ bodies, characters } = sys
   -- FIXME: dimensional analysis
   visible i a = case i of
     B (Star _) -> True
-    _          -> received .>. threshold
+    _          -> received > threshold
     where
-    received :: Mega Watts Double
-    received = (c^.ship_.radar_.power_ .*. gain .*. aperture .*. crossSection .*. patternPropagationFactor ** 4) ./. (I ((4 * pi) ** 2) .*. r .*. r)
+    received :: Pico Watts Double
+    received = (c^.ship_.radar_.power_.convertingTo (Pico . Watts) .*. gain .*. aperture .*. crossSection .*. patternPropagationFactor ** 4) ./. (I ((4 * pi) ** 2) .*. r .*. r)
     crossSection :: (Metres :*: Metres) Double
     crossSection = a^.actor_.magnitude_.convertingTo Metres .*. a^.actor_.magnitude_.convertingTo Metres
     r :: (Metres :*: Metres) Double

--- a/src/Starlight/System.hs
+++ b/src/Starlight/System.hs
@@ -88,7 +88,7 @@ neighbourhoodOf c sys@System{ bodies, characters } = sys
     received :: Mega Watts Double
     received = (c^.ship_.radar_.power_ .*. gain .*. aperture .*. crossSection .*. patternPropagationFactor ** 4) ./. (I ((4 * pi) ** 2) .*. r .*. r)
     crossSection :: (Metres :*: Metres) Double
-    crossSection = a^.actor_.magnitude_.converting @_ @Metres .*. a^.actor_.magnitude_.converting @_ @Metres
+    crossSection = a^.actor_.magnitude_.convertingTo Metres .*. a^.actor_.magnitude_.convertingTo Metres
     r :: (Metres :*: Metres) Double
     r = pure $ fmap (getMetres . convert) (a^.actor_.position_) `qd` fmap (getMetres . convert) (c^.actor_.position_)
   aperture :: (Metres :*: Metres) Double

--- a/src/Unit.hs
+++ b/src/Unit.hs
@@ -13,6 +13,7 @@ module Unit
 , unitary
 , convert
 , converting
+, convertingFrom
 , convertingTo
   -- ** Comparison
 , (.==.)
@@ -63,6 +64,9 @@ convert = pure . (/ getConst (factor @_ @u')) . (* getConst (factor @_ @u)) . pr
 
 converting :: forall u u' a b dim . (Unit dim u, Unit dim u', Fractional a, Fractional b) => Iso (u a) (u b) (u' a) (u' b)
 converting = iso convert convert
+
+convertingFrom :: (Unit dim u, Unit dim u', Fractional a, Fractional b) => (forall a . a -> u a) -> Iso (u a) (u b) (u' a) (u' b)
+convertingFrom _ = converting
 
 convertingTo :: (Unit dim u, Unit dim u', Fractional a, Fractional b) => (forall a . a -> u' a) -> Iso (u a) (u b) (u' a) (u' b)
 convertingTo _ = converting

--- a/src/Unit.hs
+++ b/src/Unit.hs
@@ -31,6 +31,7 @@ import Control.Lens.Iso
 import Data.Char
 import Data.Coerce
 import Data.Functor.Const
+import Data.Functor.Identity
 import Numeric
 
 -- * Units
@@ -44,6 +45,9 @@ class Applicative u => Unit (dim :: * -> *) u | u -> dim where
   factor = 1
 
   suffix :: Const ShowS (u a)
+
+instance Unit Identity Identity where
+  suffix = Const id
 
 unitary :: forall u a b dim . (Unit dim u, Fractional a, Fractional b) => Iso (u a) (u b) a b
 unitary = iso ((* getConst (factor @_ @u)) . prj) (pure . (/ getConst (factor @_ @u)))

--- a/src/Unit.hs
+++ b/src/Unit.hs
@@ -64,7 +64,7 @@ convert = pure . (/ getConst (factor @_ @u')) . (* getConst (factor @_ @u)) . pr
 converting :: forall u u' a b dim . (Unit dim u, Unit dim u', Fractional a, Fractional b) => Iso (u a) (u b) (u' a) (u' b)
 converting = iso convert convert
 
-convertingTo :: (Unit dim u, Unit dim u', Fractional a, Fractional b) => (forall a . a -> u a) -> Iso (u a) (u b) (u' a) (u' b)
+convertingTo :: (Unit dim u, Unit dim u', Fractional a, Fractional b) => (forall a . a -> u' a) -> Iso (u a) (u b) (u' a) (u' b)
 convertingTo _ = converting
 
 

--- a/src/Unit.hs
+++ b/src/Unit.hs
@@ -93,7 +93,7 @@ infix 4 .>=.
 -- ** Formatting
 
 formatWith :: Unit dim u => (Maybe Int -> u a -> ShowS) -> Maybe Int -> u a -> String
-formatWith with n u = with n u (getConst (suffix `asTypeOf` (u <$ Const ('x':))) "")
+formatWith with n u = with n u (showChar ' ' (getConst (suffix `asTypeOf` (u <$ Const ('x':))) ""))
 
 format :: (Unit dim u, RealFloat (u a)) => Maybe Int -> u a -> String
 format = formatWith showGFloat

--- a/src/Unit.hs
+++ b/src/Unit.hs
@@ -12,6 +12,7 @@ module Unit
   Unit(..)
 , unitary
 , convert
+, convertFrom
 , convertTo
 , converting
 , convertingFrom
@@ -62,6 +63,9 @@ unitary = iso ((* getConst (factor @_ @u)) . prj) (pure . (/ getConst (factor @_
 
 convert :: forall u u' a dim . (Unit dim u, Unit dim u', Fractional a) => u a -> u' a
 convert = pure . (/ getConst (factor @_ @u')) . (* getConst (factor @_ @u)) . prj
+
+convertFrom :: (Unit dim u, Unit dim u', Fractional a) => (forall a . a -> u a) -> u a -> u' a
+convertFrom _ = convert
 
 convertTo :: (Unit dim u, Unit dim u', Fractional a) => (forall a . a -> u' a) -> u a -> u' a
 convertTo _ = convert

--- a/src/Unit.hs
+++ b/src/Unit.hs
@@ -12,6 +12,7 @@ module Unit
   Unit(..)
 , unitary
 , convert
+, convertTo
 , converting
 , convertingFrom
 , convertingTo
@@ -61,6 +62,9 @@ unitary = iso ((* getConst (factor @_ @u)) . prj) (pure . (/ getConst (factor @_
 
 convert :: forall u u' a dim . (Unit dim u, Unit dim u', Fractional a) => u a -> u' a
 convert = pure . (/ getConst (factor @_ @u')) . (* getConst (factor @_ @u)) . prj
+
+convertTo :: (Unit dim u, Unit dim u', Fractional a) => (forall a . a -> u' a) -> u a -> u' a
+convertTo _ = convert
 
 converting :: forall u u' a b dim . (Unit dim u, Unit dim u', Fractional a, Fractional b) => Iso (u a) (u b) (u' a) (u' b)
 converting = iso convert convert

--- a/src/Unit.hs
+++ b/src/Unit.hs
@@ -10,7 +10,6 @@
 module Unit
 ( -- * Units
   Unit(..)
-, unitary
 , convert
 , convertFrom
 , convertTo
@@ -57,9 +56,6 @@ instance Unit I I where
 
 instance Unit Identity Identity where
   suffix = Const (showChar '1')
-
-unitary :: forall u a b dim . (Unit dim u, Fractional a, Fractional b) => Iso (u a) (u b) a b
-unitary = iso ((* getConst (factor @_ @u)) . prj) (pure . (/ getConst (factor @_ @u)))
 
 convert :: forall u u' a dim . (Unit dim u, Unit dim u', Fractional a) => u a -> u' a
 convert = pure . (/ getConst (factor @_ @u')) . (* getConst (factor @_ @u)) . prj

--- a/src/Unit.hs
+++ b/src/Unit.hs
@@ -47,7 +47,7 @@ class Applicative u => Unit (dim :: * -> *) u | u -> dim where
   suffix :: Const ShowS (u a)
 
 instance Unit Identity Identity where
-  suffix = Const id
+  suffix = Const (showChar '1')
 
 unitary :: forall u a b dim . (Unit dim u, Fractional a, Fractional b) => Iso (u a) (u b) a b
 unitary = iso ((* getConst (factor @_ @u)) . prj) (pure . (/ getConst (factor @_ @u)))

--- a/src/Unit.hs
+++ b/src/Unit.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE MultiWayIf #-}
+{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeOperators #-}
@@ -12,6 +13,7 @@ module Unit
 , unitary
 , convert
 , converting
+, convertingTo
   -- ** Comparison
 , (.==.)
 , compareU
@@ -61,6 +63,9 @@ convert = pure . (/ getConst (factor @_ @u')) . (* getConst (factor @_ @u)) . pr
 
 converting :: forall u u' a b dim . (Unit dim u, Unit dim u', Fractional a, Fractional b) => Iso (u a) (u b) (u' a) (u' b)
 converting = iso convert convert
+
+convertingTo :: (Unit dim u, Unit dim u', Fractional a, Fractional b) => (forall a . a -> u a) -> Iso (u a) (u b) (u' a) (u' b)
+convertingTo _ = converting
 
 
 -- ** Comparison

--- a/src/Unit.hs
+++ b/src/Unit.hs
@@ -31,6 +31,7 @@ import Control.Lens.Iso
 import Data.Char
 import Data.Coerce
 import Data.Functor.Const
+import Data.Functor.I
 import Data.Functor.Identity
 import Numeric
 
@@ -45,6 +46,9 @@ class Applicative u => Unit (dim :: * -> *) u | u -> dim where
   factor = 1
 
   suffix :: Const ShowS (u a)
+
+instance Unit I I where
+  suffix = Const (showChar '1')
 
 instance Unit Identity Identity where
   suffix = Const (showChar '1')

--- a/src/Unit/Algebra.hs
+++ b/src/Unit/Algebra.hs
@@ -17,7 +17,7 @@ module Unit.Algebra
 , (./.)
   -- * Combinators
 , (:*:)(..)
-, (:/:)
+, (:/:)(..)
 , Inv(..)
 ) where
 

--- a/src/Unit/Algebra.hs
+++ b/src/Unit/Algebra.hs
@@ -19,6 +19,7 @@ module Unit.Algebra
 , (:*:)(..)
 , (:/:)(..)
 , Inv(..)
+, I
 ) where
 
 import Data.Functor.Const
@@ -128,3 +129,6 @@ infixl 7 :/:
 instance (Unit dimu u, Unit dimv v) => Unit (dimu :/: dimv) (u :/: v) where
   factor = Const (getConst (factor @_ @u) / getConst (factor @_ @v))
   suffix = Const (getConst (suffix @_ @u) . ('/' :) . getConst (suffix @_ @v))
+
+
+type I = Identity

--- a/src/Unit/Algebra.hs
+++ b/src/Unit/Algebra.hs
@@ -17,7 +17,8 @@ module Unit.Algebra
 , (./.)
   -- * Combinators
 , (:*:)(..)
-, (:/:)(..)
+-- , (:/:)(..)
+, (:/:)
 , Inv(..)
 , I
 , Identity(..)
@@ -122,15 +123,17 @@ instance Unit dimu u => Unit dimu (Inv u) where
   suffix = Const (getConst (suffix @_ @u) . ('⁻' :) . ('¹' :))
 
 
-newtype ((u :: * -> *) :/: (v :: * -> *)) a = Per { getPer :: a }
-  deriving (Conjugate, Epsilon, Enum, Eq, Foldable, Floating, Fractional, Functor, Integral, Num, Ord, Real, RealFloat, RealFrac, Scalar, Show, Storable, Traversable, GL.Type, Uniform)
-  deriving (Additive, Applicative, Metric, Monad) via Identity
+-- newtype ((u :: * -> *) :/: (v :: * -> *)) a = Per { getPer :: a }
+--   deriving (Conjugate, Epsilon, Enum, Eq, Foldable, Floating, Fractional, Functor, Integral, Num, Ord, Real, RealFloat, RealFrac, Scalar, Show, Storable, Traversable, GL.Type, Uniform)
+--   deriving (Additive, Applicative, Metric, Monad) via Identity
+
+type u :/: v = u :*: Inv v
 
 infixl 7 :/:
 
-instance (Unit dimu u, Unit dimv v) => Unit (dimu :/: dimv) (u :/: v) where
-  factor = Const (getConst (factor @_ @u) / getConst (factor @_ @v))
-  suffix = Const (getConst (suffix @_ @u) . ('/' :) . getConst (suffix @_ @v))
+-- instance (Unit dimu u, Unit dimv v) => Unit (dimu :/: dimv) (u :/: v) where
+--   factor = Const (getConst (factor @_ @u) / getConst (factor @_ @v))
+--   suffix = Const (getConst (suffix @_ @u) . ('/' :) . getConst (suffix @_ @v))
 
 
 type I = Identity

--- a/src/Unit/Algebra.hs
+++ b/src/Unit/Algebra.hs
@@ -81,7 +81,8 @@ instance {-# OVERLAPPABLE #-} (Mul dimu u dimv v, Unit dimu' u') => MulBy 'Walk 
 
 
 type family Mul' u v where
-  Mul' u v = u :*: v
+  Mul' (u :/: v) v = u
+  Mul' u         v = u :*: v
 
 type family Div' u v where
   Div' u v = u :/: v

--- a/src/Unit/Algebra.hs
+++ b/src/Unit/Algebra.hs
@@ -94,6 +94,7 @@ type family Step u v where
   Step _             _         = 'Prepend
 
 type family InvOf u where
+  InvOf I       = I
   InvOf (Inv u) = u
   InvOf u       = Inv u
 

--- a/src/Unit/Algebra.hs
+++ b/src/Unit/Algebra.hs
@@ -80,17 +80,6 @@ instance {-# OVERLAPPABLE #-} (Mul dimu u dimv v, Unit dimu' u') => MulBy 'Walk 
   Prd u `mulBy` v = Prd (u * prj v)
 
 
-type family Mul' u v where
-  Mul' v         Identity = v
-  Mul' Identity  v        = v
-  Mul' (u :/: v) v        = u
-  Mul' u         v        = u :*: v
-
-type family Div' u v where
-  Div' (u :*: v) u = v
-  Div' (u :*: v) v = u
-  Div' u         v = u :/: v
-
 data Act = Prepend | CancelL | CancelR | Decompose | Walk
 
 type family Step u v where

--- a/src/Unit/Algebra.hs
+++ b/src/Unit/Algebra.hs
@@ -13,7 +13,7 @@
 {-# LANGUAGE UndecidableInstances #-}
 module Unit.Algebra
 (  -- * Algebra
-  Mul(..)
+  Alg(..)
 , (./.)
   -- * Combinators
 , (:*:)(..)
@@ -34,48 +34,48 @@ import Unit
 
 -- * Algebra
 
-class (Unit dimu u, Unit dimv v) => Mul dimu u dimv v | u -> dimu, v -> dimv where
+class (Unit dimu u, Unit dimv v) => Alg dimu u dimv v | u -> dimu, v -> dimv where
   type Res u v (c :: (* -> *) -> (* -> *) -> (* -> *)) :: * -> *
   (.*.) :: Fractional a => u a -> v a -> Res u v (:*:) a
 
 infixl 7 .*.
 
-(./.) :: forall dimu u dimv v a . (Mul dimu u dimv (Inv v), Unit dimv v, Fractional a) => u a -> v a -> Res u (Inv v) (:*:) a
+(./.) :: forall dimu u dimv v a . (Alg dimu u dimv (Inv v), Unit dimv v, Fractional a) => u a -> v a -> Res u (Inv v) (:*:) a
 u ./. v = u .*. Inv @v (1/prj v)
 
 infixl 7 ./.
 
-instance (MulBy step dimu u dimv v, Step u v ~ step, Unit dimu u, Unit dimv v) => Mul dimu u dimv v where
+instance (AlgBy step dimu u dimv v, Step u v ~ step, Unit dimu u, Unit dimv v) => Alg dimu u dimv v where
   type Res u v c = ResBy (Step u v) u v c
   (.*.) = mulBy @step
 
 
-class (Unit dimu u, Unit dimv v) => MulBy (step :: Act) dimu u dimv v where
+class (Unit dimu u, Unit dimv v) => AlgBy (step :: Act) dimu u dimv v where
   type ResBy step u v (c :: (* -> *) -> (* -> *) -> (* -> *)) :: * -> *
   mulBy :: Fractional a => u a -> v a -> ResBy step u v (:*:) a
 
 -- | Prepend at the head of the chain.
-instance {-# OVERLAPPABLE #-} (Unit dimu u, Unit dimv v) => MulBy 'Prepend dimu u dimv v where
+instance {-# OVERLAPPABLE #-} (Unit dimu u, Unit dimv v) => AlgBy 'Prepend dimu u dimv v where
   type ResBy 'Prepend u v (:*:) = u :*: v
   u `mulBy` v = Prd (prj u * prj v)
 
 -- | Elimination by reciprocals at left.
-instance {-# OVERLAPPABLE #-} (Unit dimu u, Unit dimv v, Unit dimu' u', u' ~ InvOf u) => MulBy 'CancelL (dimu :*: dimv) (u :*: v) dimu' u' where
+instance {-# OVERLAPPABLE #-} (Unit dimu u, Unit dimv v, Unit dimu' u', u' ~ InvOf u) => AlgBy 'CancelL (dimu :*: dimv) (u :*: v) dimu' u' where
   type ResBy 'CancelL (u :*: v) u' (:*:) = v
   u `mulBy` v = pure (prj u * prj v)
 
 -- | Elimination by reciprocals at right.
-instance {-# OVERLAPPABLE #-} (Unit dimu u, Unit dimv v, Unit dimv' v', v' ~ InvOf v) => MulBy 'CancelR (dimu :*: dimv) (u :*: v) dimv' v' where
+instance {-# OVERLAPPABLE #-} (Unit dimu u, Unit dimv v, Unit dimv' v', v' ~ InvOf v) => AlgBy 'CancelR (dimu :*: dimv) (u :*: v) dimv' v' where
   type ResBy 'CancelR (u :*: v) v' (:*:) = u
   u `mulBy` v = pure (prj u * prj v)
 
 -- | Decompose products on the right.
-instance {-# OVERLAPPABLE #-} (Mul dimu u dimv' v', Mul dimuv' (Res u v' (:*:)) dimv v, Unit dimv' v', Unit dimuv'v (Res (Res u v' (:*:)) v (:*:))) => MulBy 'Decompose dimu u (dimv :*: dimv') (v :*: v') where
+instance {-# OVERLAPPABLE #-} (Alg dimu u dimv' v', Alg dimuv' (Res u v' (:*:)) dimv v, Unit dimv' v', Unit dimuv'v (Res (Res u v' (:*:)) v (:*:))) => AlgBy 'Decompose dimu u (dimv :*: dimv') (v :*: v') where
   type ResBy 'Decompose u (v :*: v') (:*:) = Res (Res u v' (:*:)) v (:*:)
   u `mulBy` Prd v = pure (prj u * v)
 
 -- | Walk the chain.
-instance {-# OVERLAPPABLE #-} (Mul dimu u dimv v, Unit dimu' u') => MulBy 'Walk (dimu :*: dimu') (u :*: u') dimv v where
+instance {-# OVERLAPPABLE #-} (Alg dimu u dimv v, Unit dimu' u') => AlgBy 'Walk (dimu :*: dimu') (u :*: u') dimv v where
   type ResBy 'Walk (u :*: u') v (:*:) = Res u v (:*:) :*: u'
   Prd u `mulBy` v = Prd (u * prj v)
 

--- a/src/Unit/Algebra.hs
+++ b/src/Unit/Algebra.hs
@@ -126,6 +126,12 @@ instance Unit dimu u => Unit dimu (Inv u) where
   suffix = Const (getConst (suffix @_ @u) . ('⁻' :) . ('¹' :))
 
 
-type (u :/: v) = u :*: Inv v
+newtype ((u :: * -> *) :/: (v :: * -> *)) a = Per { getPer :: a }
+  deriving (Conjugate, Epsilon, Enum, Eq, Foldable, Floating, Fractional, Functor, Integral, Num, Ord, Real, RealFloat, RealFrac, Scalar, Show, Storable, Traversable, GL.Type, Uniform)
+  deriving (Additive, Applicative, Metric, Monad) via Identity
 
 infixl 7 :/:
+
+instance (Unit dimu u, Unit dimv v) => Unit (dimu :/: dimv) (u :/: v) where
+  factor = Const (getConst (factor @_ @u) / getConst (factor @_ @v))
+  suffix = Const (getConst (suffix @_ @u) . ('/' :) . getConst (suffix @_ @v))

--- a/src/Unit/Algebra.hs
+++ b/src/Unit/Algebra.hs
@@ -81,9 +81,10 @@ instance {-# OVERLAPPABLE #-} (Mul dimu u dimv v, Unit dimu' u') => MulBy 'Walk 
 
 
 type family Mul' u v where
-  Mul' Identity  v = v
-  Mul' (u :/: v) v = u
-  Mul' u         v = u :*: v
+  Mul' v         Identity = v
+  Mul' Identity  v        = v
+  Mul' (u :/: v) v        = u
+  Mul' u         v        = u :*: v
 
 type family Div' u v where
   Div' (u :*: v) u = v

--- a/src/Unit/Algebra.hs
+++ b/src/Unit/Algebra.hs
@@ -54,7 +54,7 @@ class (Unit dimu u, Unit dimv v) => MulBy (step :: Act) dimu u dimv v where
   type ResBy step u v :: * -> *
   mulBy :: Fractional a => u a -> v a -> ResBy step u v a
 
--- | Append at the head of the chain.
+-- | Prepend at the head of the chain.
 instance {-# OVERLAPPABLE #-} (Unit dimu u, Unit dimv v) => MulBy 'Prepend dimu u dimv v where
   type ResBy 'Prepend u v = u :*: v
   u `mulBy` v = Prd (prj u * prj v)

--- a/src/Unit/Algebra.hs
+++ b/src/Unit/Algebra.hs
@@ -52,7 +52,7 @@ instance (AlgBy step dimu u dimv v, Step u v ~ step, Unit dimu u, Unit dimv v) =
   (.*.) = mulBy @step
 
 
-class (Unit dimu u, Unit dimv v) => AlgBy (step :: Act) dimu u dimv v where
+class (Unit dimu u, Unit dimv v) => AlgBy (step :: Act) dimu u dimv v | u -> dimu, v -> dimv where
   type ResBy step u v (c :: (* -> *) -> (* -> *) -> (* -> *)) :: * -> *
   mulBy :: Fractional a => u a -> v a -> ResBy step u v (:*:) a
 

--- a/src/Unit/Algebra.hs
+++ b/src/Unit/Algebra.hs
@@ -81,6 +81,7 @@ instance {-# OVERLAPPABLE #-} (Mul dimu u dimv v, Unit dimu' u') => MulBy 'Walk 
 
 
 type family Mul' u v where
+  Mul' Identity  v = v
   Mul' (u :/: v) v = u
   Mul' u         v = u :*: v
 

--- a/src/Unit/Algebra.hs
+++ b/src/Unit/Algebra.hs
@@ -13,6 +13,8 @@ module Unit.Algebra
 (  -- * Algebra
   (.*.)
 , (./.)
+  -- * Calculation
+, qdU
   -- * Combinators
 , (:*:)(..)
 , (:/:)
@@ -54,6 +56,13 @@ type family Mul u v where
   Mul  u            (Inv (v :*: w)) = Mul (Mul u (Inv w)) (Inv v) -- u / (v * w) = (u / w) / v
   Mul (u :*: v)           w         = Mul u w :*: v               -- (u * v) * w = (u * w) * v
   Mul  u                  v         = u :*: v                     -- u * v       = u * v
+
+
+-- * Calculation
+
+-- | Compute the square of the distance efficiently and in the correct dimensions.
+qdU :: (Metric v, Unit du u, Num a) => v (u a) -> v (u a) -> (u :*: u) a
+u `qdU` v = pure $ fmap prj u `qd` fmap prj v
 
 
 -- * Combinators

--- a/src/Unit/Algebra.hs
+++ b/src/Unit/Algebra.hs
@@ -4,8 +4,8 @@
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
@@ -14,13 +14,12 @@
 {-# LANGUAGE UndecidableInstances #-}
 module Unit.Algebra
 (  -- * Algebra
-  Alg(..)
+  (.*.)
 , (./.)
   -- * Combinators
 , (:*:)(..)
--- , (:/:)(..)
-, (:/:)
-, Inv(..)
+, (:/:)(..)
+, Inv
 , I
 , pattern I
 , getI
@@ -40,67 +39,30 @@ import Unit
 
 -- * Algebra
 
-class (Unit dimu u, Unit dimv v) => Alg dimu u dimv v | u -> dimu, v -> dimv where
-  type Res u v (c :: (* -> *) -> (* -> *) -> (* -> *)) :: * -> *
-  (.*.) :: Fractional a => u a -> v a -> Res u v (:*:) a
+(.*.) :: (Unit du u, Unit dv v, Unit dw (Simplify (u :*: v)), Fractional a) => u a -> v a -> Simplify (u :*: v) a
+u .*. v = pure (prj v * prj u)
 
 infixl 7 .*.
 
-(./.) :: forall dimu u dimv v a . (Alg dimu u dimv (Inv v), Unit dimv v, Fractional a) => u a -> v a -> Res u (Inv v) (:*:) a
-u ./. v = u .*. Inv @v (1/prj v)
+(./.) :: (Unit du u, Unit dv v, Unit dw (Simplify (u :/: v)), Fractional a) => u a -> v a -> Simplify (u :/: v) a
+u ./. v = pure (prj u / prj v)
 
 infixl 7 ./.
 
-instance (AlgBy step dimu u dimv v, Step u v ~ step, Unit dimu u, Unit dimv v) => Alg dimu u dimv v where
-  type Res u v c = ResBy (Step u v) u v c
-  (.*.) = mulBy @step
-
-
-class (Unit dimu u, Unit dimv v) => AlgBy (step :: Act (* -> *)) dimu u dimv v | u -> dimu, v -> dimv where
-  type ResBy step u v (c :: (* -> *) -> (* -> *) -> (* -> *)) :: * -> *
-  mulBy :: Fractional a => u a -> v a -> ResBy step u v (:*:) a
-
--- | Prepend at the head of the chain.
-instance {-# OVERLAPPABLE #-} (Unit dimu u, Unit dimv v) => AlgBy 'Prepend dimu u dimv v where
-  type ResBy 'Prepend u v (:*:) = u :*: v
-  u `mulBy` v = Prd (prj u * prj v)
-
--- | Elimination by reciprocals at left.
-instance {-# OVERLAPPABLE #-} (Unit dimu u, Unit dimv v, Unit dimu' u', u' ~ InvOf u) => AlgBy ('Cancel v) (dimu :*: dimv) (u :*: v) dimu' u' where
-  type ResBy ('Cancel v) (u :*: v) u' (:*:) = v
-  u `mulBy` v = pure (prj u * prj v)
-
--- | Elimination by reciprocals at right.
-instance {-# OVERLAPPABLE #-} (Unit dimu u, Unit dimv v, Unit dimv' v', v' ~ InvOf v) => AlgBy ('Cancel u) (dimu :*: dimv) (u :*: v) dimv' v' where
-  type ResBy ('Cancel u) (u :*: v) v' (:*:) = u
-  u `mulBy` v = pure (prj u * prj v)
-
--- | Decompose products on the right.
-instance {-# OVERLAPPABLE #-} (Alg dimu u dimv' v', Alg dimuv' (Res u v' (:*:)) dimv v, Unit dimv' v', Unit dimuv'v (Res (Res u v' (:*:)) v (:*:))) => AlgBy 'Decompose dimu u (dimv :*: dimv') (v :*: v') where
-  type ResBy 'Decompose u (v :*: v') (:*:) = Res (Res u v' (:*:)) v (:*:)
-  u `mulBy` Prd v = pure (prj u * v)
-
--- | Walk the chain.
-instance {-# OVERLAPPABLE #-} (Alg dimu u dimv v, Unit dimu' u') => AlgBy 'Walk (dimu :*: dimu') (u :*: u') dimv v where
-  type ResBy 'Walk (u :*: u') v (:*:) = Res u v (:*:) :*: u'
-  Prd u `mulBy` v = Prd (u * prj v)
-
-
-data Act a = Prepend | Cancel a | Decompose | Walk
-
-type family Step u v where
-  Step (v     :*: u) (Inv v)   = 'Cancel u
-  Step (Inv v :*: u) v         = 'Cancel u
-  Step (u     :*: v) (Inv v)   = 'Cancel u
-  Step (u     :/: v) v         = 'Cancel u
-  Step _             (_ :*: _) = 'Decompose
-  Step (_     :*: _) _         = 'Walk
-  Step _             _         = 'Prepend
-
-type family InvOf u where
-  InvOf I       = I
-  InvOf (Inv u) = u
-  InvOf u       = Inv u
+type family Simplify u where
+  Simplify (I       :*: u) = u
+  Simplify (u       :*: I) = u
+  Simplify (u       :/: I) = u
+  Simplify (u :/: v :*: v) = u
+  Simplify (u :*: v :/: v) = u
+  Simplify (v :*: u :/: v) = u
+  Simplify (u :*: v :*: w) = Simplify (u :*: w) :*: v
+  Simplify (u :*: v :/: w) = Simplify (u :/: w) :*: v
+  Simplify (u :/: v :*: w) = Simplify (u :*: w) :/: v
+  Simplify (u :/: v :/: w) = Simplify (u :/: w) :/: v
+  Simplify (u :*: (v :*: w)) = Simplify (u :*: v :*: w)
+  Simplify (u :/: (v :*: w)) = Simplify (u :/: v :/: w)
+  Simplify u               = u
 
 
 -- * Combinators
@@ -116,27 +78,18 @@ instance (Unit dimu u, Unit dimv v) => Unit (dimu :*: dimv) (u :*: v) where
   suffix = Const (getConst (suffix @_ @u) . ('·' :) . getConst (suffix @_ @v))
 
 
-newtype Inv (u :: * -> *) a = Inv { getInv :: a }
+newtype ((u :: * -> *) :/: (v :: * -> *)) a = Per { getPer :: a }
   deriving (Conjugate, Epsilon, Enum, Eq, Foldable, Floating, Fractional, Functor, Integral, Num, Ord, Real, RealFloat, RealFrac, Scalar, Show, Storable, Traversable, GL.Type, Uniform)
   deriving (Additive, Applicative, Metric, Monad) via Identity
 
-instance Unit dimu u => Unit dimu (Inv u) where
-  prj = getInv
-  factor = Const (1/getConst (factor @_ @u))
-  suffix = Const (getConst (suffix @_ @u) . ('⁻' :) . ('¹' :))
-
-
--- newtype ((u :: * -> *) :/: (v :: * -> *)) a = Per { getPer :: a }
---   deriving (Conjugate, Epsilon, Enum, Eq, Foldable, Floating, Fractional, Functor, Integral, Num, Ord, Real, RealFloat, RealFrac, Scalar, Show, Storable, Traversable, GL.Type, Uniform)
---   deriving (Additive, Applicative, Metric, Monad) via Identity
-
-type u :/: v = u :*: Inv v
-
 infixl 7 :/:
 
--- instance (Unit dimu u, Unit dimv v) => Unit (dimu :/: dimv) (u :/: v) where
---   factor = Const (getConst (factor @_ @u) / getConst (factor @_ @v))
---   suffix = Const (getConst (suffix @_ @u) . ('/' :) . getConst (suffix @_ @v))
+instance (Unit dimu u, Unit dimv v) => Unit (dimu :/: dimv) (u :/: v) where
+  factor = Const (getConst (factor @_ @u) / getConst (factor @_ @v))
+  suffix = Const (getConst (suffix @_ @u) . ('/' :) . getConst (suffix @_ @v))
+
+
+type Inv u = I :/: u
 
 
 type I = Identity

--- a/src/Unit/Algebra.hs
+++ b/src/Unit/Algebra.hs
@@ -80,6 +80,12 @@ instance {-# OVERLAPPABLE #-} (Mul dimu u dimv v, Unit dimu' u') => MulBy 'Walk 
   Prd u `mulBy` v = Prd (u * prj v)
 
 
+type family Mul' u v where
+  Mul' u v = u :*: v
+
+type family Div' u v where
+  Div' u v = u :/: v
+
 data Act = Prepend | CancelL | CancelR | Decompose | Walk
 
 type family Step u v where

--- a/src/Unit/Algebra.hs
+++ b/src/Unit/Algebra.hs
@@ -86,7 +86,7 @@ type family Step u v where
   Step (v     :*: _)     (Inv v)   = 'CancelL
   Step (Inv v :*: _)     v         = 'CancelL
   Step (_     :*: v)     (Inv v)   = 'CancelR
-  Step (_     :/: v) v         = 'CancelR
+  Step (_     :/: v) v             = 'CancelR
   Step _                 (_ :*: _) = 'Decompose
   Step (_     :*: _)     _         = 'Walk
   Step _                 _         = 'Prepend

--- a/src/Unit/Algebra.hs
+++ b/src/Unit/Algebra.hs
@@ -85,6 +85,7 @@ type family Mul' u v where
   Mul' u         v = u :*: v
 
 type family Div' u v where
+  Div' (u :*: v) u = v
   Div' (u :*: v) v = u
   Div' u         v = u :/: v
 

--- a/src/Unit/Algebra.hs
+++ b/src/Unit/Algebra.hs
@@ -20,6 +20,7 @@ module Unit.Algebra
 , (:/:)(..)
 , Inv(..)
 , I
+, Identity(..)
 ) where
 
 import Data.Functor.Const

--- a/src/Unit/Algebra.hs
+++ b/src/Unit/Algebra.hs
@@ -17,8 +17,8 @@ module Unit.Algebra
 , (./.)
   -- * Combinators
 , (:*:)(..)
-, Inv(..)
 , (:/:)
+, Inv(..)
 ) where
 
 import Data.Functor.Const

--- a/src/Unit/Algebra.hs
+++ b/src/Unit/Algebra.hs
@@ -75,11 +75,6 @@ instance (Unit dimu u, Unit dimv v) => Unit (dimu :*: dimv) (u :*: v) where
   suffix = Const (getConst (suffix @_ @u) . ('·' :) . getConst (suffix @_ @v))
 
 
-type u :/: v = u :*: Inv v
-
-infixl 7 :/:
-
-
 newtype Inv (u :: * -> *) a = Inv { getInv :: a }
   deriving (Conjugate, Epsilon, Enum, Eq, Foldable, Floating, Fractional, Functor, Integral, Num, Ord, Real, RealFloat, RealFrac, Scalar, Show, Storable, Traversable, GL.Type, Uniform)
   deriving (Additive, Applicative, Metric, Monad) via Identity
@@ -88,6 +83,11 @@ instance Unit dimu u => Unit dimu (Inv u) where
   prj = getInv
   factor = Const (1/getConst (factor @_ @u))
   suffix = Const (getConst (suffix @_ @u) . ('⁻' :) . ('¹' :))
+
+
+type u :/: v = u :*: Inv v
+
+infixl 7 :/:
 
 
 type I = Identity

--- a/src/Unit/Algebra.hs
+++ b/src/Unit/Algebra.hs
@@ -6,7 +6,6 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
@@ -20,14 +19,11 @@ module Unit.Algebra
 , (:*:)(..)
 , (:/:)
 , Inv(..)
-, I
-, pattern I
-, getI
-, Identity(..)
+, I(..)
 ) where
 
 import Data.Functor.Const
-import Data.Functor.Identity
+import Data.Functor.I
 import Foreign.Storable
 import GL.Type as GL
 import GL.Uniform
@@ -66,7 +62,7 @@ type family Mul u v where
 
 newtype ((u :: * -> *) :*: (v :: * -> *)) a = Prd { getPrd :: a }
   deriving (Conjugate, Epsilon, Enum, Eq, Foldable, Floating, Fractional, Functor, Integral, Num, Ord, Real, RealFloat, RealFrac, Scalar, Show, Storable, Traversable, GL.Type, Uniform)
-  deriving (Additive, Applicative, Metric, Monad) via Identity
+  deriving (Additive, Applicative, Metric, Monad) via I
 
 infixl 7 :*:
 
@@ -77,7 +73,7 @@ instance (Unit dimu u, Unit dimv v) => Unit (dimu :*: dimv) (u :*: v) where
 
 newtype Inv (u :: * -> *) a = Inv { getInv :: a }
   deriving (Conjugate, Epsilon, Enum, Eq, Foldable, Floating, Fractional, Functor, Integral, Num, Ord, Real, RealFloat, RealFrac, Scalar, Show, Storable, Traversable, GL.Type, Uniform)
-  deriving (Additive, Applicative, Metric, Monad) via Identity
+  deriving (Additive, Applicative, Metric, Monad) via I
 
 instance Unit dimu u => Unit dimu (Inv u) where
   prj = getInv
@@ -88,15 +84,3 @@ instance Unit dimu u => Unit dimu (Inv u) where
 type u :/: v = u :*: Inv v
 
 infixl 7 :/:
-
-
-type I = Identity
-
-pattern I :: a -> Identity a
-pattern I a = Identity a
-
-getI :: I a -> a
-getI = runIdentity
-{-# INLINABLE getI #-}
-
-{-# COMPLETE I #-}

--- a/src/Unit/Algebra.hs
+++ b/src/Unit/Algebra.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE AllowAmbiguousTypes #-}
-{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveTraversable #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}

--- a/src/Unit/Algebra.hs
+++ b/src/Unit/Algebra.hs
@@ -85,7 +85,8 @@ type family Mul' u v where
   Mul' u         v = u :*: v
 
 type family Div' u v where
-  Div' u v = u :/: v
+  Div' (u :*: v) v = u
+  Div' u         v = u :/: v
 
 data Act = Prepend | CancelL | CancelR | Decompose | Walk
 

--- a/src/Unit/Algebra.hs
+++ b/src/Unit/Algebra.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
@@ -21,6 +22,7 @@ module Unit.Algebra
 , (:/:)
 , Inv(..)
 , I
+, pattern I
 , Identity(..)
 ) where
 
@@ -137,3 +139,8 @@ infixl 7 :/:
 
 
 type I = Identity
+
+pattern I :: a -> Identity a
+pattern I a = Identity a
+
+{-# COMPLETE I #-}

--- a/src/Unit/Algebra.hs
+++ b/src/Unit/Algebra.hs
@@ -94,13 +94,13 @@ type family Div' u v where
 data Act = Prepend | CancelL | CancelR | Decompose | Walk
 
 type family Step u v where
-  Step (v     :*: _)     (Inv v)   = 'CancelL
-  Step (Inv v :*: _)     v         = 'CancelL
-  Step (_     :*: v)     (Inv v)   = 'CancelR
-  Step (_     :/: v) v             = 'CancelR
-  Step _                 (_ :*: _) = 'Decompose
-  Step (_     :*: _)     _         = 'Walk
-  Step _                 _         = 'Prepend
+  Step (v     :*: _) (Inv v)   = 'CancelL
+  Step (Inv v :*: _) v         = 'CancelL
+  Step (_     :*: v) (Inv v)   = 'CancelR
+  Step (_     :/: v) v         = 'CancelR
+  Step _             (_ :*: _) = 'Decompose
+  Step (_     :*: _) _         = 'Walk
+  Step _             _         = 'Prepend
 
 type family InvOf u where
   InvOf (Inv u) = u

--- a/src/Unit/Algebra.hs
+++ b/src/Unit/Algebra.hs
@@ -23,6 +23,7 @@ module Unit.Algebra
 , Inv(..)
 , I
 , pattern I
+, getI
 , Identity(..)
 ) where
 
@@ -142,5 +143,9 @@ type I = Identity
 
 pattern I :: a -> Identity a
 pattern I a = Identity a
+
+getI :: I a -> a
+getI = runIdentity
+{-# INLINABLE getI #-}
 
 {-# COMPLETE I #-}

--- a/starlight.cabal
+++ b/starlight.cabal
@@ -51,6 +51,7 @@ library
     Control.Effect.Thread
     Control.Exception.Lift
     Control.Monad.IO.Class.Lift
+    Data.Functor.I
     Data.Functor.Interval
     Foreign.C.String.Lift
     Foreign.Marshal.Alloc.Lift


### PR DESCRIPTION
This PR adds dimensionless quantities, represented as `Identity`. It also simplifies `Unit.Algebra` down to two functions, one (recursive) typeclass, two existing `newtype`s, the existing `:/:` type synonym, and some synonyms for `Identity`.